### PR TITLE
Free dynamically allocated strings

### DIFF
--- a/src/llamacpp_fetch.c
+++ b/src/llamacpp_fetch.c
@@ -195,5 +195,6 @@ llamacpp_fetch(config_t *config, const char *prompt, int history_length)
 	char *text_response = llamacpp_get_response_content(json_response.ptr);
 	free(json_request.ptr);
 	free(json_response.ptr);
+	free(system_role);
 	return text_response;
 }

--- a/src/openai_fetch.c
+++ b/src/openai_fetch.c
@@ -159,5 +159,7 @@ openai_fetch(config_t *config, const char *prompt, int history_length)
 	char *text_response = openai_get_response_content(json_response.ptr);
 	free(json_request.ptr);
 	free(json_response.ptr);
+	free(system_role);
+	free(authorization);
 	return text_response;
 }


### PR DESCRIPTION
I believe that `safe_asprintf` dynamically allocates memory for the first argument, but that is not freed after the fetchers are done with them.