### PR TITLE
Change error output to errorformat

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -186,7 +186,7 @@ ini_checked_parse(const char* filename, ini_handler handler, config_t *config)
 	int val = ini_parse(filename, handler, config);
 	// When unable to open file val is -1, which we ignore
 	if (val > 0) {
-		fprintf(stderr, "%s(%d): Initialization file error.\n", filename, val);
+		fprintf(stderr, "%s:%d:1: Initialization file error.\n", filename, val);
 		exit(EXIT_FAILURE);
 	}
 }


### PR DESCRIPTION
Refs https://github.com/dspinellis/ai-cli-lib/issues/6

I just assume the column number to be 1; even if that is not always correct.

The output is IMHO more clearer then.