### PR TITLE
Add link to model list

### DIFF
--- a/src/ai-cli-config
+++ b/src/ai-cli-config
@@ -6,7 +6,8 @@ context = 3
 endpoint = https://api.openai.com/v1/chat/completions
 model = gpt-3.5-turbo
 ; The following is more capable, but requires having an established
-; payment relationship
+; payment relationship. All models including limits are listed at
+; https://platform.openai.com/account/limits
 ; model = gpt-4
 temperature = 0.7
 ; User-specific: add it in a local protected file


### PR DESCRIPTION
This adds a link to https://platform.openai.com/account/limits in the configuration file