### PR TITLE
Ability to override prompt config section with program specific vals

### DIFF
--- a/src/openai_fetch.c
+++ b/src/openai_fetch.c
@@ -72,6 +72,12 @@ static int
 initialize(config_t *config)
 {
 	program_name = short_program_name();
+
+        if (config->general_verbose) {
+            fprintf(stderr, "Initializing openAI API, program name [%s] system prompt to use [%s]\n",
+                    program_name, config->prompt_system);
+        }
+
 	safe_asprintf(&authorization, "Authorization: Bearer %s", config->openai_key);
 	safe_asprintf(&system_role, config->prompt_system, program_name);
 	return curl_initialize(config);
@@ -88,6 +94,9 @@ openai_fetch(config_t *config, const char *prompt, int history_length)
 
 	if (!curl && initialize(config) < 0)
 		return NULL;
+
+	if (config->general_verbose)
+            fprintf(stderr, "... Contacting openai API...\n");
 
 	struct curl_slist *headers = NULL;
 	headers = curl_slist_append(headers, "Content-Type: application/json");


### PR DESCRIPTION
It is now possible to have system and context in a program section. For example:

    [prompt-sqlite3]
    system=You are an assistant who provides SQL commands for sqlite3. ... 
    context=1

In addition, add verbose debugging errors and more importantly, if the config does not parse, output the tokens that are responsible for this problem.

It also adds a verbose message when the prompt is send to OpenAI. Other backends might need to be updated.